### PR TITLE
Change variable name to not conflict with GM YYC compiler. 

### DIFF
--- a/scripts/GMLodash/GMLodash.gml
+++ b/scripts/GMLodash/GMLodash.gml
@@ -671,19 +671,19 @@ function GMLodash() constructor {
 		return result;
 	};
 	
-	static join = function join(collection, seperator) {
+	static join = function join(collection, separator) {
 		var adapter = get_adapter_for(collection);
 		var result = "";
-		seperator = seperator == undefined ? "," : seperator;
+		separator = separator == undefined ? "," : separator;
 		
 		var stack = ds_stack_create();
 		for (var i = 0, isize = adapter.size(collection); i < isize; ++i) {
 			var value = adapter.get(collection, i);
 			ds_stack_push(stack, [value, isize - 1]);
 			while(!ds_stack_empty(stack)) {
-				var args = ds_stack_pop(stack);
-				value = args[0];
-				var limit = args[1];
+				var arguments = ds_stack_pop(stack);
+				value = arguments[0];
+				var limit = arguments[1];
 				
 				if (is_collection(value)) {
 					var jadapter = get_adapter_for(value);
@@ -695,7 +695,7 @@ function GMLodash() constructor {
 				else {
 					result += string(value);
 					if (i < limit)
-						result += seperator;
+						result += separator;
 				}
 			}
 		}


### PR DESCRIPTION
1. Minor: fix spelling of one variable (seperator -> separator).
2. Changing the variable `args` to `arguments` fixes a GM compilation error when trying to build in YYC mode. The full error I encountered is:

```
Z:/veil-of-du_12E257B1_CFC6F286/veil-of-dust/Default/Scripts/llvm-win/gml_GlobalScript_scr_gmLodash.gml.cpp:4678:10: error: redefinition of 'local_args' with a different type: 'YYRValue' vs 'YYLocalArgs'
YYRValue local_args;
         ^
Z:/veil-of-du_12E257B1_CFC6F286/veil-of-dust/Default/Scripts/llvm-win/gml_GlobalScript_scr_gmLodash.gml.cpp:4666:13: note: previous definition is here
YYLocalArgs local_args( _count, 2, _args );
            ^
Z:/veil-of-du_12E257B1_CFC6F286/veil-of-dust/Default/Scripts/llvm-win/gml_GlobalScript_scr_gmLodash.gml.cpp:4762:11: error: no viable overloaded '='
local_args=YYGML_ds_stack_pop((int)(int64)((int)(int64)/* local */local_stack.asReal()));
~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
X://yyc/include\YYGML.h:2328:8: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'YYRValue' to 'const YYLocalArgs' for 1st argument
struct YYLocalArgs
       ^
Z:/veil-of-du_12E257B1_CFC6F286/veil-of-dust/Default/Scripts/llvm-win/gml_GlobalScript_scr_gmLodash.gml.cpp:4765:153: error: type 'YYLocalArgs' does not provide a subscript operator
local_value=/* array index changed from System.Collections.Generic.List`1[System.String] to System.Collections.Generic.List`1[System.String]*/local_args[(int)(0)];
                                                                                                                                              ~~~~~~~~~~^~~~~~~~~
Z:/veil-of-du_12E257B1_CFC6F286/veil-of-dust/Default/Scripts/llvm-win/gml_GlobalScript_scr_gmLodash.gml.cpp:4769:37: error: type 'YYLocalArgs' does not provide a subscript operator
local_limit=/* volatile */local_args[(int)(1)];
                          ~~~~~~~~~~^~~~~~~~~
4 errors generated.
```

I don't have a serious understanding of this error, but my guess is that somewhere under the hood, the GM compiler is also using the variable name `args` and it is causing a conflict. Renaming it to anything else resolves this issue and allows the YYC compiler to build correctly. (Although I'm not able to call any GMLodash methods yet; there is another GM bug to be fixed).