### PR TITLE
Add boolean check to isEqual function, and adds two other functions

### DIFF
--- a/scripts/GMLodash/GMLodash.gml
+++ b/scripts/GMLodash/GMLodash.gml
@@ -671,19 +671,19 @@ function GMLodash() constructor {
 		return result;
 	};
 	
-	static join = function join(collection, seperator) {
+	static join = function join(collection, separator) {
 		var adapter = get_adapter_for(collection);
 		var result = "";
-		seperator = seperator == undefined ? "," : seperator;
+		separator = separator == undefined ? "," : separator;
 		
 		var stack = ds_stack_create();
 		for (var i = 0, isize = adapter.size(collection); i < isize; ++i) {
 			var value = adapter.get(collection, i);
 			ds_stack_push(stack, [value, isize - 1]);
 			while(!ds_stack_empty(stack)) {
-				var args = ds_stack_pop(stack);
-				value = args[0];
-				var limit = args[1];
+				var arguments = ds_stack_pop(stack);
+				value = arguments[0];
+				var limit = arguments[1];
 				
 				if (is_collection(value)) {
 					var jadapter = get_adapter_for(value);
@@ -695,7 +695,7 @@ function GMLodash() constructor {
 				else {
 					result += string(value);
 					if (i < limit)
-						result += seperator;
+						result += separator;
 				}
 			}
 		}

--- a/scripts/GMLodash/GMLodash.gml
+++ b/scripts/GMLodash/GMLodash.gml
@@ -1,3 +1,11 @@
+// Project:
+// https://github.com/DatZach/GMLodash
+
+// Documentation:
+// https://github.com/DatZach/GMLodash/wiki/Collections
+// https://github.com/DatZach/GMLodash/wiki/Language
+// https://github.com/DatZach/GMLodash/wiki/Utility
+
 #macro _ gmLodashInstance()
 
 function GMLodash() constructor {
@@ -242,7 +250,34 @@ function GMLodash() constructor {
 		
 		return false;
 	};
-	
+
+	// For simple array-checking, this is more performant than the `includes` function.
+	static flatArrayIncludes = function flatArrayIncludes(array, value) {
+	  for(var i = 0; i < array_length(array); i++) {
+	    if(array[i] == value) {
+	      return true;
+	    }
+	  }
+	  return false;
+	};
+
+	// Returns the index of an item within a collection.
+	static indexOf = function indexOf(collection, iteratee) {
+		var adapter = get_adapter_for(collection);
+		var keys = adapter.keys(collection);
+		iteratee = get_iteratee(iteratee);
+
+		for (var i = 0, isize = adapter.size(collection); i < isize; ++i) {
+			var key = adapter.isMap ? keys[i] : i;
+			var value = adapter.get(collection, key);
+			if(iteratee(value, key, collection)) {
+				return i;
+			}
+		}
+
+		return undefined;
+	};
+
 	static keyBy = function keyBy(collection, iteratee) {
 		var cadapter = get_adapter_for(collection);
 		var radapter = get_map_adapter_for(collection);
@@ -516,6 +551,8 @@ function GMLodash() constructor {
 		}
 		else if (is_ptr(a) && is_ptr(b))
 			return a == b;
+		else if (is_bool(a) && is_bool(b))
+			return a == b;
 
 		// TODO More types?
 		
@@ -699,7 +736,6 @@ function GMLodash() constructor {
 				}
 			}
 		}
-		
 		ds_stack_destroy(stack);
 		return result;
 	};


### PR DESCRIPTION
## One fix and two new functions

1. As of Gamemaker release `2.3.7.603` (https://gms.yoyogames.com/ReleaseNotes.html), I found that a struct with a value of `true` was being evaluated as `True` within the IDE, whereas before it was evaluated as a `1`. This was causing Gamemaker to fail, because the `isEqual` function did not have a boolean comparator.
2. Separately, adds two new functions:
  i. `indexOf`, which returns the index of an item within a collection.
  ii. `flatArrayIncludes`, which can only check flat arrays but is more performant than the `includes` function.